### PR TITLE
FoodItem.BaseShelfLife changed from int to float

### DIFF
--- a/FreshMilk.cs
+++ b/FreshMilk.cs
@@ -24,7 +24,7 @@ namespace Eco.Mods.TechTree
         
         public override float Calories                  => 120;
         public override Nutrients Nutrition             => new Nutrients() { Carbs = 3, Fat = 7, Protein = 10, Vitamins = 0};
-		protected override int BaseShelfLife => (int)TimeUtil.HoursToSeconds(72);
+        protected override float BaseShelfLife => (int)TimeUtil.HoursToSeconds(72);
     }
 
 }

--- a/HerbivoreLureItem.cs
+++ b/HerbivoreLureItem.cs
@@ -22,7 +22,7 @@ namespace Eco.Mods.TechTree
         
         public override float Calories                  => 800;
         public override Nutrients Nutrition             => new Nutrients() { Carbs = 18, Fat = 4, Protein = 6, Vitamins = 10};
-		protected override int BaseShelfLife => (int)TimeUtil.HoursToSeconds(72);
+        protected override float BaseShelfLife => (int)TimeUtil.HoursToSeconds(72);
     }
 
 }

--- a/HerbivoreRationItem.cs
+++ b/HerbivoreRationItem.cs
@@ -22,7 +22,7 @@ namespace Eco.Mods.TechTree
         
         public override float Calories                  => 800;
         public override Nutrients Nutrition             => new Nutrients() { Carbs = 18, Fat = 4, Protein = 6, Vitamins = 10};
-		protected override int BaseShelfLife => (int)TimeUtil.HoursToSeconds(72);
+        protected override float BaseShelfLife => (int)TimeUtil.HoursToSeconds(72);
     }
 
 }


### PR DESCRIPTION
This may have changed the standard indentation character or the endline character of the affected files, because I used windows git with autocrlf

Without this change, the current modkit and newer versions will throw an exception and prevent the server from starting.